### PR TITLE
Updated for making init.d work

### DIFF
--- a/prebuilt/common/etc/init.local.rc
+++ b/prebuilt/common/etc/init.local.rc
@@ -43,4 +43,3 @@ on property:service.adb.tcp.port=-1
 service sysinit /system/bin/sysinit
     user root
     oneshot
-    disabled


### PR DESCRIPTION
Hi, this change is to enable the init.d functionality which I have tested on my Oneplus One.

The change enables the sysinit service.
